### PR TITLE
swidden:success/1のspecを修正した

### DIFF
--- a/src/swidden.erl
+++ b/src/swidden.erl
@@ -2,11 +2,13 @@
 
 -export([start/1, start/2, stop/0]).
 -export([success/0, success/1, failure/1]).
+-export_type([json_object/0]).
 
 -define(DEFAULT_HEADER_NAME, <<"x-swd-target">>).
 
 -define(REF, swidden_http_api).
 
+-type json_object() :: jsone:json_object().
 
 %% TODO(nakai): Target も Opts に入れてしまうかどうか検討すること
 
@@ -55,7 +57,7 @@ success() ->
     ok.
 
 
--spec success([{atom(), binary()}]) -> {ok, [{atom(), binary()}]}.
+-spec success(json_object()) -> {ok, json_object()}.
 success(JSON) ->
     {ok, JSON}.
 


### PR DESCRIPTION
`[{atom(), binary()}]` だと特定の型しか変換できないが、
実際は `jsone:json_object()` 型であれば変換可能である。

ただ jsone を外に見せるのは良く無さそうなので、
自前で定義して export_type し直した。

----

`erlang:memory/0` の結果を `swidden:success/1` に渡すと、動作的には問題ないのですが、dialyzer を掛けると、`erlang:memory/0`の戻り値の型が `[{atom(), non_neg_integer()}]` であるため警告が出てしまうので修正してみました。